### PR TITLE
Support Arabic comma in cleanAuthor

### DIFF
--- a/utilities.js
+++ b/utilities.js
@@ -167,7 +167,7 @@ var Utilities = {
 			// Add spaces between periods
 			author = author.replace(/\.([^ ])/, ". $1");
 
-			var splitNames = author.split(/, ?/);
+			var splitNames = author.split(/[,،] ?/);
 			if(splitNames.length > 1) {
 				var lastName = splitNames[0];
 				var firstName = splitNames[1];


### PR DESCRIPTION
The Arabic script (Arabic, Persian, Urdu, etc.) uses an inverted comma to separate names, and we should treat it equivalently to the Latin comma.