### PR TITLE
Add function to map localized language names to ISO codes

### DIFF
--- a/test/tests/utilities_itemTest.js
+++ b/test/tests/utilities_itemTest.js
@@ -236,6 +236,38 @@ describe("Zotero.Utilities.Item", function () {
 			assert.equal(accessed['date-parts'][0][1], 1);
 			assert.equal(accessed['date-parts'][0][2], 9);
 		});
+
+		it("should convert localized language names to ISO 639-1", function () {
+			let item = newItem('journalArticle');
+
+			item.language = 'French';
+			let language = Zotero.Utilities.Item.itemToCSLJSON(item).language;
+			assert.equal(language, 'fr');
+
+			item.language = 'francais'; // Diacritics are ignored
+			language = Zotero.Utilities.Item.itemToCSLJSON(item).language;
+			assert.equal(language, 'fr');
+
+			item.language = 'foobar';
+			language = Zotero.Utilities.Item.itemToCSLJSON(item).language;
+			assert.equal(language, 'foobar');
+
+			item.language = 'zh-Hans';
+			language = Zotero.Utilities.Item.itemToCSLJSON(item).language;
+			assert.equal(language, 'zh-Hans');
+
+			item.language = 'العربية';
+			language = Zotero.Utilities.Item.itemToCSLJSON(item).language;
+			assert.equal(language, 'ar');
+
+			// If Intl is unavailable, should return the input value
+			let Intl = globalThis.Intl;
+			globalThis.Intl = undefined;
+			item.language = 'French';
+			language = Zotero.Utilities.Item.itemToCSLJSON(item).language;
+			assert.equal(language, 'French');
+			globalThis.Intl = Intl;
+		});
 	});
 
 

--- a/utilities_item.js
+++ b/utilities_item.js
@@ -741,9 +741,7 @@ var Utilities_Item = {
 			return language;
 		}
 
-		let originalLanguage = language;
-		// Lowercase and remove diacritics
-		language = language.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+		let normalize = s => s.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
 
 		let languageMap = Utilities_Item._languageMap;
 		if (!languageMap) {
@@ -751,22 +749,27 @@ var Utilities_Item = {
 
 			let allLocales = ["ab", "aa", "af", "ak", "sq", "am", "ar", "an", "hy", "as", "av", "ae", "ay", "az", "bm", "ba", "eu", "be", "bn", "bi", "bs", "br", "bg", "my", "ca", "ch", "ce", "ny", "zh", "cu", "cv", "kw", "co", "cr", "hr", "cs", "da", "dv", "nl", "dz", "en", "eo", "et", "ee", "fo", "fj", "fi", "fr", "fy", "ff", "gd", "gl", "lg", "ka", "de", "el", "kl", "gn", "gu", "ht", "ha", "he", "hz", "hi", "ho", "hu", "is", "io", "ig", "id", "ia", "ie", "iu", "ik", "ga", "it", "ja", "jv", "kn", "kr", "ks", "kk", "km", "ki", "rw", "ky", "kv", "kg", "ko", "kj", "ku", "lo", "la", "lv", "li", "ln", "lt", "lu", "lb", "mk", "mg", "ms", "ml", "mt", "gv", "mi", "mr", "mh", "mn", "na", "nv", "nd", "nr", "ng", "ne", "no", "nb", "nn", "ii", "oc", "oj", "or", "om", "os", "pi", "ps", "fa", "pl", "pt", "pa", "qu", "ro", "rm", "rn", "ru", "se", "sm", "sg", "sa", "sc", "sr", "sn", "sd", "si", "sk", "sl", "so", "st", "es", "su", "sw", "ss", "sv", "tl", "ty", "tg", "ta", "tt", "te", "th", "bo", "ti", "to", "ts", "tn", "tr", "tk", "tw", "ug", "uk", "ur", "uz", "ve", "vi", "vo", "wa", "cy", "wo", "xh", "yi", "yo", "za", "zu"];
 			let englishLanguageNames = new Intl.DisplayNames('en', { type: 'language' });
+			let userLanguageNames = new Intl.DisplayNames(Zotero.locale, { type: 'language' });
 			for (let locale of Intl.DisplayNames.supportedLocalesOf(allLocales)) {
 				let inEnglish = englishLanguageNames.of(locale);
 				if (inEnglish) {
-					languageMap.set(inEnglish.toLowerCase(), locale);
+					languageMap.set(normalize(inEnglish), locale);
+				}
+
+				let inUser = userLanguageNames.of(locale);
+				if (inUser) {
+					languageMap.set(normalize(inUser), locale);
 				}
 			
-				let localeLanguageNames = new Intl.DisplayNames(locale, { type: 'language' });
-				let inLocale = localeLanguageNames.of(locale);
-				if (inLocale) {
-					inLocale = inLocale.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
-					languageMap.set(inLocale, locale);
+				let selfLanguageNames = new Intl.DisplayNames(locale, { type: 'language' });
+				let inSelf = selfLanguageNames.of(locale);
+				if (inSelf) {
+					languageMap.set(normalize(inSelf), locale);
 				}
 			}
 		}
 
-		return languageMap.get(language) || originalLanguage;
+		return languageMap.get(normalize(language)) || language;
 	},
 
 	/**

--- a/utilities_item.js
+++ b/utilities_item.js
@@ -103,9 +103,6 @@ var Utilities_Item = {
 					else if (field == 'extra') {
 						value = Zotero.Utilities.Item.extraToCSL(value);
 					}
-					else if (field == 'language') {
-						value = Zotero.Utilities.Item.languageToCSL(value);
-					}
 
 					// Strip enclosing quotes
 					if(value.charAt(0) == '"' && value.indexOf('"', 1) == value.length - 1) {
@@ -734,7 +731,7 @@ var Utilities_Item = {
 	 * @param {String} language
 	 * @return {String}
 	 */
-	languageToCSL: function (language) {
+	languageToISO6391: function (language) {
 		if (!language) {
 			return '';
 		}


### PR DESCRIPTION
We could extract the mapping generation to a build script and just load some JSON at runtime, but the procedure that builds it is fast - less than a hundredth of a second on my machine - and it only has to run once, so I wasn't sure it would be worth the added complexity.