### PR TITLE
`Zotero.Utilities.varDump()`: Set `maxLevel` for all Nodes/Windows

### DIFF
--- a/utilities.js
+++ b/utilities.js
@@ -1480,6 +1480,10 @@ var Utilities = {
 				level = maxLevel;
 			}
 		}
+		// Do the same for cross-context Node and Window objects
+		if (obj.hasOwnProperty('nodeType') || objType === '[object Window]') {
+			level = maxLevel;
+		}
 
 		// Recursion checking
 		if(!parentObjects) {


### PR DESCRIPTION
Fixes `varDump()` (and `Zotero.debug()`) practically never returning when called on `document` in the browser or on a node from another frame.