### PR TITLE
Enable seeAlso for CSLJSON import/export

### DIFF
--- a/utilities_item.js
+++ b/utilities_item.js
@@ -213,6 +213,8 @@ var Utilities_Item = {
 			cslItem.title = Zotero.Utilities.Item.noteToTitle(zoteroItem.note);
 		}
 
+		cslItem.seeAlso = zoteroItem.seeAlso;
+
 		//this._cache[zoteroItem.id] = cslItem;
 		return cslItem;
 	},
@@ -397,6 +399,7 @@ var Utilities_Item = {
 				}
 			}
 		}
+		item.seeAlso = cslItem.seeAlso;
 	},
 
 	/**


### PR DESCRIPTION
This is a companion to https://github.com/zotero/zotero/pull/3085, enabling ``seeAlso`` relations for the CSLJSON converters.