### PR TITLE
Fix always-true comparisons in `isToday()`

### DIFF
--- a/date.js
+++ b/date.js
@@ -872,8 +872,8 @@ var Utilities_Date = new function(){
 	function isToday(date) {
 		var d = new Date();
 		return d.getDate() == date.getDate()
-			&& d.getMonth() == d.getMonth()
-			&& d.getFullYear() == d.getFullYear();
+			&& d.getMonth() == date.getMonth()
+			&& d.getFullYear() == date.getFullYear();
 	}
 
 


### PR DESCRIPTION
`isToday()` was returning true for any date with the same day of the month, whether or not the month and year were the same.