### PR TITLE
cleanDOI: Handle malformed URI escape sequence

### DIFF
--- a/test/tests/utilitiesTest.js
+++ b/test/tests/utilitiesTest.js
@@ -112,6 +112,10 @@ describe("Zotero.Utilities", function() {
 		it("should parse a DOI in brackets", function () {
 			assert.equal(cleanDOI(`Foo bar [${doi}] foo bar`), doi);
 		});
+
+		it("should parse a DOI with an invalid URI-encoded character", function () {
+			assert.equal(cleanDOI('https://doi.org/10.101/%E0%A4%A'))
+		});
 	});
 	
 	

--- a/utilities.js
+++ b/utilities.js
@@ -482,9 +482,14 @@ var Utilities = {
 		if(typeof(x) != "string") {
 			throw new Error("cleanDOI: argument must be a string");
 		}
-		// If it's a URL, decode it
-		if (x.match(/^https?:/)) {
-			x = decodeURIComponent(x);
+		// If it's a URL, try to decode it
+		if (/^https?:/.test(x)) {
+			try {
+				x = decodeURIComponent(x);
+			}
+			catch (e) {
+				// URI contains an invalid escape sequence - ignore
+			}
 		}
 		// Even if it's not a URL, decode %3C followed by %3E as < >
 		var openingPos = x.indexOf("%3C");

--- a/utilities.js
+++ b/utilities.js
@@ -488,7 +488,8 @@ var Utilities = {
 				x = decodeURIComponent(x);
 			}
 			catch (e) {
-				// URI contains an invalid escape sequence - ignore
+				// URI contains an invalid escape sequence
+				Zotero.debug("Not decoding URL-like DOI because of invalid escape sequence: " + x);
 			}
 		}
 		// Even if it's not a URL, decode %3C followed by %3E as < >


### PR DESCRIPTION
Fixes zotero/zotero#4571