### PR TITLE
`languageToISO6391()`: Fix underscore-separated codes

### DIFF
--- a/test/tests/utilities_itemTest.js
+++ b/test/tests/utilities_itemTest.js
@@ -402,5 +402,21 @@ describe("Zotero.Utilities.Item", function () {
 			assert.equal(language, 'French');
 			globalThis.Intl = Intl;
 		});
+
+		it("should resolve underscore-separated codes", function () {
+			var language = 'en_US';
+			language = Zotero.Utilities.Item.languageToISO6391(language);
+			assert.equal(language, 'en-US');
+
+			language = 'zh_Hans';
+			language = Zotero.Utilities.Item.languageToISO6391(language)
+			assert.equal(language, 'zh-Hans');
+		});
+
+		it("should not modify input containing an underscore if it isn't a language code", function () {
+			var language = 'some_other_underscore_stuff';
+			language = Zotero.Utilities.Item.languageToISO6391(language)
+			assert.equal(language, 'some_other_underscore_stuff');
+		});
 	});
 });

--- a/utilities_item.js
+++ b/utilities_item.js
@@ -735,8 +735,8 @@ var Utilities_Item = {
 			return '';
 		}
 
-		if (!globalThis.Intl || !globalThis.Intl.DisplayNames) {
-			Zotero.debug('Intl.DisplayNames not available: returning language as-is');
+		if (!globalThis.Intl || !globalThis.Intl.DisplayNames || !globalThis.Intl.Locale) {
+			Zotero.debug('Intl not available: returning language as-is');
 			return language;
 		}
 
@@ -768,7 +768,29 @@ var Utilities_Item = {
 			}
 		}
 
-		return languageMap.get(normalize(language)) || language;
+		let normalized = normalize(language);
+		// If it's a localized language name, return the language's code
+		if (languageMap.has(normalized)) {
+			return languageMap.get(normalized);
+		}
+		
+		// Is the input a valid locale code?
+		try {
+			new Intl.Locale(language);
+		}
+		catch (e) {
+			try {
+				new Intl.Locale(language.replace(/_/g, '-'));
+				// No, but language with _ substituted for - (e.g. en_US -> en-US) is
+				// Return that
+				return language.replace(/_/g, '-');
+			}
+			catch (e) {
+			}
+			// All other cases: return the original input
+		}
+		
+		return language;
 	},
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/zotero/zotero/issues/4753