### PR TITLE
sentenceCase: Preserve casing for words with non-letter characters

### DIFF
--- a/test/data/sentenceCase.json
+++ b/test/data/sentenceCase.json
@@ -738,5 +738,6 @@
   "Monte-Carlo Exploration for Deterministic Planning": "Monte-carlo exploration for deterministic planning",
   "Seventh International Planning Competition": "Seventh international planning competition",
   "Activity Planning for a Lunar Orbital Mission": "Activity planning for a lunar orbital mission",
-  "Essentials of Artificial Intelligence": "Essentials of artificial intelligence"
+  "Essentials of Artificial Intelligence": "Essentials of artificial intelligence",
+  "The Temperature is 1200 °C": "The temperature is 1200 °C"
 }

--- a/utilities.js
+++ b/utilities.js
@@ -170,6 +170,11 @@ var Utilities = {
 					return word
 				}
 
+				// If the word contains any non-letter character, retain its original case
+				if (unmasked.match(/[^a-zA-Z]/)) {
+					return word;
+				}
+
 				return word.toLowerCase()
 			});
 

--- a/utilities.js
+++ b/utilities.js
@@ -171,7 +171,7 @@ var Utilities = {
 				}
 
 				// If the word contains any non-letter character, retain its original case
-				if (unmasked.match(/[^a-zA-Z]/)) {
+				if (unmasked.match(/[^a-z]/i)) {
 					return word;
 				}
 


### PR DESCRIPTION
EDITED: Sorry for the disturbance, I misinterpreted the existing code and this pr is not necessary.

---

ref: https://github.com/northword/zotero-format-metadata/issues/263

```
# original title
1200 °C

# to sentence case - before this pr
1200 °c

# to sentence case - after this pr
1200 °C
```