### PR TITLE
chore: fix test script for windows and improve readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Please bundle the [Zotero schema](https://github.com/zotero/zotero-schema) file 
 To run tests:
 
 ```bash
-git clone --recursive https://github.com/zotero/utilities.git utilities/
-cd utilities/
+git clone --recursive https://github.com/zotero/utilities.git
+cd utilities
 npm i
 npm test
 ```

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ Please bundle the [Zotero schema](https://github.com/zotero/zotero-schema) file 
 To run tests:
 
 ```bash
-# Git submodule is required
 git clone --recursive https://github.com/zotero/utilities.git utilities/
 cd utilities/
 npm i

--- a/README.md
+++ b/README.md
@@ -4,18 +4,14 @@ Zotero utility code common across various codebases such as the Zotero client,
 Zotero translation architecture and others.
 
 Item utility functions require:
-
 - Calling `Zotero.Schema.init(json)` with the JSON from `schema.json` from Zotero schema repo
 - Calling `Zotero.Date.init(json)` with the JSON from `resource/dateFormats.json`
 - Loading `resource/zoteroTypeSchemaData.js` before `cachedTypes.js` or in Node.js running
-
   ```js
     let CachedTypes = require('./cachedTypes')
     CachedTypes.setTypeSchema(require('./resource/zoteroTypeSchemaData'))
   ```
-
 - Implementing `Zotero.localeCompare()`; a simple implementation would be
-
   ```js
     let collator = new Intl.Collator(['en-US'], {
       numeric: true,

--- a/README.md
+++ b/README.md
@@ -4,14 +4,18 @@ Zotero utility code common across various codebases such as the Zotero client,
 Zotero translation architecture and others.
 
 Item utility functions require:
+
 - Calling `Zotero.Schema.init(json)` with the JSON from `schema.json` from Zotero schema repo
 - Calling `Zotero.Date.init(json)` with the JSON from `resource/dateFormats.json`
 - Loading `resource/zoteroTypeSchemaData.js` before `cachedTypes.js` or in Node.js running
+
   ```js
     let CachedTypes = require('./cachedTypes')
     CachedTypes.setTypeSchema(require('./resource/zoteroTypeSchemaData'))
   ```
+
 - Implementing `Zotero.localeCompare()`; a simple implementation would be
+
   ```js
     let collator = new Intl.Collator(['en-US'], {
       numeric: true,
@@ -22,4 +26,12 @@ Item utility functions require:
 
 Please bundle the [Zotero schema](https://github.com/zotero/zotero-schema) file with your repository, do not load it remotely.
 
-To run tests: `npm i && npm test`.
+To run tests:
+
+```bash
+# Git submodule is required
+git clone --recursive https://github.com/zotero/utilities.git utilities/
+cd utilities/
+npm i
+npm test
+```

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "test/runtests.sh"
+    "test": "bash test/runtests.sh"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Fix test script

On Windows, the script cannot be run without an interpreter:

![PixPin_2025-01-15_20-30-23](https://github.com/user-attachments/assets/506c67bb-bdc9-4810-afa0-1c00f50a1206)


![PixPin_2025-01-15_20-30-00](https://github.com/user-attachments/assets/07df81e9-f26a-450f-87c0-82678ed17c57)

## Improve readme

Emphasizing that git submodules are required in the readme is a good idea, although developers can find out about the existence of submodules from `.gitmodules`, but may overlook them, e.g. https://github.com/zotero/utilities/pull/26#issuecomment-1666620475 was also unaware of the need for submodules, and now mentioning this in the readme makes it more conducive for newcomers to contribute code.