### PR TITLE
Check OpenURL DC metadata for possible book type.

### DIFF
--- a/openurl.js
+++ b/openurl.js
@@ -236,6 +236,13 @@ var OpenURL = new function() {
 					break;
 				} else if(format == "info:ofi/fmt:kev:mtx:dc") {
 					item.itemType = "webpage";
+					var book_formats = ["book", "print", "text", "e_book", "ebook", "e-book"];
+					for(let j=0; j < book_formats.length; j++) {
+						if(coParts.indexOf("rft.format=" + book_formats[j]) !== -1) {
+							format_type = "book";
+						}
+					}
+					item.itemType = format_type;
 					break;
 				}
 			}


### PR DESCRIPTION
We have noticed Zotero is saving eBooks as webpages instead of books from our catalog (https://iucat.iu.edu). Currently, code is setting all OpenURLs using DC metadata format as type webpage. This PR attempts to make exceptions to this rule for items that are in fact books. 

In our case, ebooks are returning `rft.format=e_book`, so was added to list of exceptions.