### PR TITLE
Migrate to ESM

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,12 @@ Zotero translation architecture and others.
 Item utility functions require:
 - Calling `Zotero.Schema.init(json)` with the JSON from `schema.json` from Zotero schema repo
 - Calling `Zotero.Date.init(json)` with the JSON from `resource/dateFormats.json`
-- Loading `resource/zoteroTypeSchemaData.js` before `cachedTypes.js` or in Node.js running
+- Running
   ```js
-    let CachedTypes = require('./cachedTypes')
-    CachedTypes.setTypeSchema(require('./resource/zoteroTypeSchemaData'))
+    import CachedTypes from './cachedTypes.js'
+    import { ZOTERO_TYPE_SCHEMA } from './resource/zoteroTypeSchemaData.js'
+
+    CachedTypes.setTypeSchema(ZOTERO_TYPE_SCHEMA)
   ```
 - Implementing `Zotero.localeCompare()`; a simple implementation would be
   ```js

--- a/cachedTypes.js
+++ b/cachedTypes.js
@@ -27,17 +27,17 @@
  * Emulates very small parts of cachedTypes.js and itemFields.js APIs for use with connector
  */
 
-(function() {
+import Utilities from "./utilities.js";
 
-var TypeSchema;
+let TypeSchema;
 if (typeof ZOTERO_TYPE_SCHEMA != 'undefined') {
 	TypeSchema = ZOTERO_TYPE_SCHEMA;
 }
 
-var CachedTypes = new function() {
+const CachedTypes = new function() {
 	const schemaTypes = ["itemTypes", "creatorTypes", "fields"];
-	var typeData = {};
-	var itemTypes, creatorTypes, fields;
+	let typeData = {};
+	let itemTypes, creatorTypes, fields;
 
 	this.setTypeSchema = function(typeSchema) {
 		TypeSchema = typeSchema;
@@ -46,7 +46,7 @@ var CachedTypes = new function() {
 		// attach IDs and make referenceable by either ID or name
 		for (let i = 0; i < schemaTypes.length; i++) {
 			let schemaType = schemaTypes[i];
-			typeData[schemaType] = Zotero.Utilities.deepCopy(TypeSchema[schemaType]);
+			typeData[schemaType] = Utilities.deepCopy(TypeSchema[schemaType]);
 			for (let id in TypeSchema[schemaType]) {
 				let entry = typeData[schemaType][id];
 				entry.unshift(parseInt(id, 10));
@@ -73,17 +73,17 @@ var CachedTypes = new function() {
 		}
 
 		getID(idOrName) {
-			var type = this.type[idOrName];
+			const type = this.type[idOrName];
 			return (type ? type[0]/* id */ : false);
 		}
 
 		getName(idOrName) {
-			var type = this.type[idOrName];
+			const type = this.type[idOrName];
 			return (type ? type[1]/* name */ : false);
 		}
 
 		getLocalizedString(idOrName) {
-			var type = this.type[idOrName];
+			const type = this.type[idOrName];
 			return (type ? type[2]/* localizedString */ : false);
 		}
 	}
@@ -100,20 +100,20 @@ var CachedTypes = new function() {
 		}
 		
 		getTypesForItemType(idOrName) {
-			var itemType = itemTypes[idOrName];
+			const itemType = itemTypes[idOrName];
 			if(!itemType) return false;
 			
-			var itemCreatorTypes = itemType[3]; // creatorTypes
+			const itemCreatorTypes = itemType[3]; // creatorTypes
 			if (!itemCreatorTypes
 					// TEMP: 'note' and 'attachment' have an array containing false
 					|| (itemCreatorTypes.length == 1 && !itemCreatorTypes[0])) {
 				return [];
 			}
-			var n = itemCreatorTypes.length;
-			var outputTypes = new Array(n);
+			const n = itemCreatorTypes.length;
+			const outputTypes = new Array(n);
 			
-			for(var i=0; i<n; i++) {
-				var creatorType = creatorTypes[itemCreatorTypes[i]];
+			for(let i=0; i<n; i++) {
+				const creatorType = creatorTypes[itemCreatorTypes[i]];
 				outputTypes[i] = {"id":creatorType[0]/* id */,
 					"name":creatorType[1]/* name */};
 			}
@@ -121,13 +121,13 @@ var CachedTypes = new function() {
 		};
 		
 		getPrimaryIDForType(idOrName) {
-			var itemType = itemTypes[idOrName];
+			const itemType = itemTypes[idOrName];
 			if(!itemType) return false;
 			return itemType[3]/* creatorTypes */[0];
 		};
 		
 		isValidForItemType(creatorTypeID, itemTypeID) {
-			let itemType = itemTypes[itemTypeID];
+			const itemType = itemTypes[itemTypeID];
 			return itemType[3]/* creatorTypes */.includes(creatorTypeID);
 		};
 	})();
@@ -138,7 +138,7 @@ var CachedTypes = new function() {
 		}
 		
 		isValidForType(fieldIdOrName, typeIdOrName) {
-			var field = fields[fieldIdOrName], itemType = itemTypes[typeIdOrName];
+			const field = fields[fieldIdOrName], itemType = itemTypes[typeIdOrName];
 			
 			// mimics itemFields.js
 			if(!field || !itemType) return false;
@@ -152,7 +152,7 @@ var CachedTypes = new function() {
 		};
 		
 		getFieldIDFromTypeAndBase(typeIdOrName, fieldIdOrName) {
-			var baseField = fields[fieldIdOrName], itemType = itemTypes[typeIdOrName];
+			let baseField = fields[fieldIdOrName], itemType = itemTypes[typeIdOrName];
 			
 			if(!baseField || !itemType) return false;
 			
@@ -160,8 +160,8 @@ var CachedTypes = new function() {
 			baseField = baseField[0]/* id */;
 			
 			// loop through base fields for item type
-			var baseFields = itemType[5];
-			for(var i in baseFields) {
+			const baseFields = itemType[5];
+			for(let i in baseFields) {
 				if(baseFields[i] === baseField) {
 					return i;
 				}
@@ -171,12 +171,12 @@ var CachedTypes = new function() {
 		};
 		
 		getBaseIDFromTypeAndField(typeIdOrName, fieldIdOrName) {
-			var field = fields[fieldIdOrName], itemType = itemTypes[typeIdOrName];
+			const field = fields[fieldIdOrName], itemType = itemTypes[typeIdOrName];
 			if(!field || !itemType) {
 				throw new Error("Invalid field or type ID");
 			}
 			
-			var baseField = itemType[5]/* baseFields */[field[0]/* id */];
+			const baseField = itemType[5]/* baseFields */[field[0]/* id */];
 			return baseField ? baseField : false;
 		};
 		
@@ -184,10 +184,7 @@ var CachedTypes = new function() {
 			return itemTypes[typeIdOrName][4]/* fields */.slice();
 		};
 	})();
-}
-if (typeof module !== 'undefined') {
-	module.exports = CachedTypes
-} else if (typeof Zotero !== 'undefined') {
-	Object.assign(Zotero, CachedTypes);
-}
-})();
+}();
+
+export { CachedTypes };
+export default CachedTypes;

--- a/date.js
+++ b/date.js
@@ -23,9 +23,9 @@
     ***** END LICENSE BLOCK *****
 */
 
-(function() {
+import Utilities from "./utilities.js";
 
-var Utilities_Date = new function(){
+const Utilities_Date = new function() {
 	this.isSQLDate = isSQLDate;
 	this.isSQLDateTime = isSQLDateTime;
 	this.sqlHasYear = sqlHasYear;
@@ -94,7 +94,7 @@ var Utilities_Date = new function(){
 		let months = _monthsWithEnglish.short.map(m => m.toLowerCase())
 			.concat(_monthsWithEnglish.long.map(m => m.toLowerCase()));
 		// TODO: Switch back to native RegExp in Fx102 when Unicode property escapes are supported
-		_monthRe = Zotero.Utilities.XRegExp("(.*)(?:^|[^\\p{L}])(" + months.join("|") + ")[^ ]*(?: (.*)$|$)", "iu");
+		_monthRe = Utilities.XRegExp("(.*)(?:^|[^\\p{L}])(" + months.join("|") + ")[^ ]*(?: (.*)$|$)", "iu");
 	};
 
 
@@ -183,12 +183,12 @@ var Utilities_Date = new function(){
 				var seconds = date.getSeconds();
 			}
 
-			year = Zotero.Utilities.lpad(year, '0', 4);
-			month = Zotero.Utilities.lpad(month + 1, '0', 2);
-			day = Zotero.Utilities.lpad(day, '0', 2);
-			hours = Zotero.Utilities.lpad(hours, '0', 2);
-			minutes = Zotero.Utilities.lpad(minutes, '0', 2);
-			seconds = Zotero.Utilities.lpad(seconds, '0', 2);
+			year = Utilities.lpad(year, '0', 4);
+			month = Utilities.lpad(month + 1, '0', 2);
+			day = Utilities.lpad(day, '0', 2);
+			hours = Utilities.lpad(hours, '0', 2);
+			minutes = Utilities.lpad(minutes, '0', 2);
+			seconds = Utilities.lpad(seconds, '0', 2);
 
 			return year + '-' + month + '-' + day + ' '
 				+ hours + ':' + minutes + ':' + seconds;
@@ -215,12 +215,12 @@ var Utilities_Date = new function(){
 		var minutes = date.getUTCMinutes();
 		var seconds = date.getUTCSeconds();
 
-		year = Zotero.Utilities.lpad(year, '0', 4);
-		month = Zotero.Utilities.lpad(month + 1, '0', 2);
-		day = Zotero.Utilities.lpad(day, '0', 2);
-		hours = Zotero.Utilities.lpad(hours, '0', 2);
-		minutes = Zotero.Utilities.lpad(minutes, '0', 2);
-		seconds = Zotero.Utilities.lpad(seconds, '0', 2);
+		year = Utilities.lpad(year, '0', 4);
+		month = Utilities.lpad(month + 1, '0', 2);
+		day = Utilities.lpad(day, '0', 2);
+		hours = Utilities.lpad(hours, '0', 2);
+		minutes = Utilities.lpad(minutes, '0', 2);
+		seconds = Utilities.lpad(seconds, '0', 2);
 
 		return year + '-' + month + '-' + day + 'T'
 			+ hours + ':' + minutes + ':' + seconds + 'Z';
@@ -275,7 +275,7 @@ var Utilities_Date = new function(){
 		};
 
 		if (typeof string == 'string' || typeof string == 'number') {
-			string = Zotero.Utilities.trimInternal(string.toString());
+			string = Utilities.trimInternal(string.toString());
 		}
 
 		// skip empty things
@@ -601,11 +601,11 @@ var Utilities_Date = new function(){
 		var date = this.strToDate(str);
 
 		if(date.year) {
-			var dateString = Zotero.Utilities.lpad(date.year, "0", 4);
+			var dateString = Utilities.lpad(date.year, "0", 4);
 			if (parseInt(date.month) == date.month) {
-				dateString += "-"+Zotero.Utilities.lpad(date.month+1, "0", 2);
+				dateString += "-"+Utilities.lpad(date.month+1, "0", 2);
 				if(date.day) {
-					dateString += "-"+Zotero.Utilities.lpad(date.day, "0", 2);
+					dateString += "-"+Utilities.lpad(date.day, "0", 2);
 				}
 			}
 			return dateString;
@@ -654,9 +654,9 @@ var Utilities_Date = new function(){
 
 		parts.month = typeof parts.month != "undefined" ? parts.month + 1 : '';
 
-		var multi = (parts.year ? Zotero.Utilities.lpad(parts.year, '0', 4) : '0000') + '-'
-			+ Zotero.Utilities.lpad(parts.month, '0', 2) + '-'
-			+ (parts.day ? Zotero.Utilities.lpad(parts.day, '0', 2) : '00')
+		var multi = (parts.year ? Utilities.lpad(parts.year, '0', 4) : '0000') + '-'
+			+ Utilities.lpad(parts.month, '0', 2) + '-'
+			+ (parts.day ? Utilities.lpad(parts.day, '0', 2) : '00')
 			+ ' '
 			+ str;
 		return multi;
@@ -946,13 +946,8 @@ var Utilities_Date = new function(){
 			}
 		}
 		return _localeDateOrder;
-	}
-}
+	};
+};
 
-if (typeof module != 'undefined') {
-	module.exports = Utilities_Date;
-} else if (typeof Zotero != 'undefined') {
-	Zotero.Date = Utilities_Date;
-}
-
-})();
+export { Utilities_Date };
+export default Utilities_Date;

--- a/openurl.js
+++ b/openurl.js
@@ -23,9 +23,10 @@
     ***** END LICENSE BLOCK *****
 */
 
-(function() {
+import Utilities from "./utilities";
+import Utilities_Item from "../utilities_item.js";
 
-var OpenURL = new function() {
+const OpenURL = new function() {
 	this.createContextObject = createContextObject;
 	this.parseContextObject = parseContextObject;
 	
@@ -148,7 +149,7 @@ var OpenURL = new function() {
 		
 		if(item.creators && item.creators.length) {
 			// encode first author as first and last
-			let firstCreator = Zotero.Utilities.Item.getFirstCreatorFromItemJSON(item);
+			let firstCreator = Utilities_Item.getFirstCreatorFromItemJSON(item);
 			if(item.itemType == "patent") {
 				_mapTag(firstCreator.firstName, "invfirst");
 				_mapTag(firstCreator.lastName, "invlast");
@@ -348,7 +349,7 @@ var OpenURL = new function() {
 					var type = "author";
 				}
 				
-				item.creators.push(_cloneIfNecessary(Zotero.Utilities.cleanAuthor(value, type, value.indexOf(",") !== -1), item));
+				item.creators.push(_cloneIfNecessary(Utilities.cleanAuthor(value, type, value.indexOf(",") !== -1), item));
 			} else if(key == "rft.aucorp") {
 				complexAu.push(_cloneIfNecessary({lastName:value, isInstitution:true}, item));
 			} else if(key == "rft.isbn" && !item.ISBN) {
@@ -408,7 +409,7 @@ var OpenURL = new function() {
 				}  else if(key == "rft.subject") {
 					item.tags.push(value);
 				} else if(key == "rft.type") {
-					if(Zotero.Utilities.Item.itemTypeExists(value)) item.itemType = value;
+					if(Utilities_Item.itemTypeExists(value)) item.itemType = value;
 				} else if(key == "rft.source") {
 					item.publicationTitle = value;
 				}
@@ -446,13 +447,8 @@ var OpenURL = new function() {
 		}
 		
 		return item;
-	}
-}
+	};
+};
 
-if (typeof module != 'undefined') {
-	module.exports = OpenURL;
-} else if (typeof Zotero != 'undefined') {
-	Zotero.OpenURL = OpenURL;
-}
-
-})();
+export { OpenURL };
+export default OpenURL;

--- a/openurl.js
+++ b/openurl.js
@@ -23,7 +23,7 @@
     ***** END LICENSE BLOCK *****
 */
 
-import Utilities from "./utilities";
+import Utilities from "./utilities.js";
 import Utilities_Item from "../utilities_item.js";
 
 const OpenURL = new function() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,25 @@
       "name": "@zotero/utilities",
       "version": "1.0.0",
       "license": "SEE LICENSE IN COPYING",
+      "dependencies": {
+        "xregexp": "^5.1.1"
+      },
       "devDependencies": {
         "chai": "^4.3.6",
         "jsdom": "^19.0.0",
         "mocha": "^9.2.2"
+      }
+    },
+    "node_modules/@babel/runtime-corejs3": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.0.tgz",
+      "integrity": "sha512-TgUkdp71C9pIbBcHudc+gXZnihEDOjUAmXO1VO4HHGES7QLZcShR0stfKIxLSNIYx2fqhmJChOjm/wkF8wv4gA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-js-pure": "^3.48.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -346,6 +361,17 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
+    },
+    "node_modules/core-js-pure": {
+      "version": "3.48.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.48.0.tgz",
+      "integrity": "sha512-1slJgk89tWC51HQ1AEqG+s2VuwpTRr8ocu4n20QUcH1v9lAN0RXen0Q0AABa/DK1I7RrNWLucplOHMx8hfTGTw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
     },
     "node_modules/cssom": {
       "version": "0.5.0",
@@ -1596,6 +1622,15 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
     },
+    "node_modules/xregexp": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-5.1.2.tgz",
+      "integrity": "sha512-6hGgEMCGhqCTFEJbqmWrNIPqfpdirdGWkqshu7fFZddmTSfgv5Sn9D2SaKloR79s5VUiUlpwzg3CM3G6D3VIlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.26.9"
+      }
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -1661,6 +1696,14 @@
     }
   },
   "dependencies": {
+    "@babel/runtime-corejs3": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.0.tgz",
+      "integrity": "sha512-TgUkdp71C9pIbBcHudc+gXZnihEDOjUAmXO1VO4HHGES7QLZcShR0stfKIxLSNIYx2fqhmJChOjm/wkF8wv4gA==",
+      "requires": {
+        "core-js-pure": "^3.48.0"
+      }
+    },
     "@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -1914,6 +1957,11 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
+    },
+    "core-js-pure": {
+      "version": "3.48.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.48.0.tgz",
+      "integrity": "sha512-1slJgk89tWC51HQ1AEqG+s2VuwpTRr8ocu4n20QUcH1v9lAN0RXen0Q0AABa/DK1I7RrNWLucplOHMx8hfTGTw=="
     },
     "cssom": {
       "version": "0.5.0",
@@ -2817,6 +2865,14 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
+    },
+    "xregexp": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-5.1.2.tgz",
+      "integrity": "sha512-6hGgEMCGhqCTFEJbqmWrNIPqfpdirdGWkqshu7fFZddmTSfgv5Sn9D2SaKloR79s5VUiUlpwzg3CM3G6D3VIlw==",
+      "requires": {
+        "@babel/runtime-corejs3": "^7.26.9"
+      }
     },
     "y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,11 @@
   "name": "@zotero/utilities",
   "version": "1.0.0",
   "description": "Zotero Utilities",
+  "type": "module",
   "main": "utilities.js",
+  "exports": {
+    ".": "./utilities.js"
+  },
   "directories": {
     "test": "test"
   },
@@ -19,6 +23,9 @@
     "url": "https://github.com/zotero/utilities/issues"
   },
   "homepage": "https://github.com/zotero/utilities#readme",
+  "dependencies": {
+    "xregexp": "^5.1.1"
+  },
   "devDependencies": {
     "chai": "^4.3.6",
     "jsdom": "^19.0.0",

--- a/resource/zoteroTypeSchemaData.js
+++ b/resource/zoteroTypeSchemaData.js
@@ -1,4 +1,4 @@
-var ZOTERO_TYPE_SCHEMA = {
+export const ZOTERO_TYPE_SCHEMA = {
 	"itemTypes": {
 		"1": [
 			"note",
@@ -2298,6 +2298,3 @@ var ZOTERO_TYPE_SCHEMA = {
 	}
 };
 
-if (typeof module !== 'undefined') {
-	module.exports = ZOTERO_TYPE_SCHEMA;
-}

--- a/schema.js
+++ b/schema.js
@@ -55,11 +55,8 @@ const Schema = {
 			let zoteroField = data.csl.fields.date[cslField];
 			Zotero.Schema.CSL_FIELD_MAPPINGS_REVERSE[zoteroField] = cslField;
 		}
-	}
+	},
 };
 
-if (typeof module != 'undefined') {
-	module.exports = Schema;
-} else if (typeof Zotero != 'undefined') {
-	Zotero.Schema = Schema;
-}
+export { Schema };
+export default Schema;

--- a/test/init.js
+++ b/test/init.js
@@ -1,5 +1,18 @@
-const fs = require('fs');
-const path = require('path');
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import chai from "chai";
+
+import Schema from "../schema.js";
+import Utilities from "../utilities.js";
+import Utilities_Item from "../utilities_item.js";
+import DateUtil from "../date.js";
+import CachedTypes from "../cachedTypes.js";
+import { ZOTERO_TYPE_SCHEMA } from "../resource/zoteroTypeSchemaData.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 // Very minimal but enough to get existing tests working
 globalThis.Zotero = {
@@ -8,10 +21,10 @@ globalThis.Zotero = {
     isNode: true
 };
 
-Zotero.Schema = require('../schema');
-Zotero.Utilities = require('../utilities');
-Zotero.Utilities.Item = require('../utilities_item');
-Zotero.Date = require('../date');
+Zotero.Schema = Schema;
+Zotero.Utilities = Utilities;
+Zotero.Utilities.Item = Utilities_Item;
+Zotero.Date = DateUtil;
 
 let schemaPath = process.env.UTILITIES_SCHEMA_PATH;
 if (!schemaPath) {
@@ -28,8 +41,7 @@ Zotero.Date.init(
     ).toString("utf-8")
 );
 
-let CachedTypes = require('../cachedTypes')
-CachedTypes.setTypeSchema(require('../resource/zoteroTypeSchemaData'));
+CachedTypes.setTypeSchema(ZOTERO_TYPE_SCHEMA);
 Object.assign(Zotero, CachedTypes);
 
 let collator = new Intl.Collator(['en-US'], {
@@ -38,7 +50,7 @@ let collator = new Intl.Collator(['en-US'], {
 });
 Zotero.localeCompare = (a, b) => collator.compare(a, b);
 
-globalThis.assert = require('chai').assert;
+globalThis.assert = chai.assert;
 
 let testDataDir = path.join(__dirname, 'data');
 

--- a/test/runtests.sh
+++ b/test/runtests.sh
@@ -33,7 +33,7 @@ while getopts "g:hj:" opt; do
 	shift $((OPTIND-1)); OPTIND=1
 done
 
-mocha \
+node --experimental-vm-modules node_modules/mocha/bin/mocha \
 	--recursive \
 	--file "$SCRIPT_DIR/init.js" \
 	--grep "$GREP" \

--- a/test/tests/utilitiesTest.js
+++ b/test/tests/utilitiesTest.js
@@ -321,10 +321,10 @@ describe("Zotero.Utilities", function() {
 	});
 	
 	describe("walkNoteDOM()", function () {
-		it("should iterate subtrees in depth-first order and allow modifications", function () {
+		it("should iterate subtrees in depth-first order and allow modifications", async function () {
 			let html = loadTestData('note.html');
 			let log = [];
-			let newHTML = Zotero.Utilities.walkNoteDOM(html, {
+			let newHTML = await Zotero.Utilities.walkNoteDOM(html, {
 				visitContainer: () => log.push('container'),
 				visitAnnotation: () => log.push('annotation'),
 				visitCitation: () => log.push('citation'),
@@ -369,9 +369,9 @@ describe("Zotero.Utilities", function() {
 			assert.notInclude(newHTML, '0000000');
 		});
 
-		it("should leave the HTML unchanged if visitors do not make modifications", function () {
+		it("should leave the HTML unchanged if visitors do not make modifications", async function () {
 			let html = loadTestData('note.html');
-			let newHTML = Zotero.Utilities.walkNoteDOM(html, {});
+			let newHTML = await Zotero.Utilities.walkNoteDOM(html, {});
 			assert.equal(newHTML, html);
 		});
 	});

--- a/test/tests/utilities_itemTest.js
+++ b/test/tests/utilities_itemTest.js
@@ -1,6 +1,6 @@
 describe("Zotero.Utilities.Item", function () {
 	describe("itemFromCSLJSON", function () {
-		it("should stably perform itemToCSLJSON -> itemFromCSLJSON -> itemToCSLJSON", function () {
+		it("should stably perform itemToCSLJSON -> itemFromCSLJSON -> itemToCSLJSON", async function () {
 			let data = loadSampleData('citeProcJSExport');
 
 			for (let i in data) {
@@ -12,9 +12,9 @@ describe("Zotero.Utilities.Item", function () {
 				}
 
 				let item = newItem();
-				Zotero.Utilities.Item.itemFromCSLJSON(item, json);
+				await Zotero.Utilities.Item.itemFromCSLJSON(item, json);
 
-				let newJSON = Zotero.Utilities.Item.itemToCSLJSON(item);
+				let newJSON = await Zotero.Utilities.Item.itemToCSLJSON(item);
 
 				delete newJSON.id;
 				delete json.id;
@@ -23,7 +23,7 @@ describe("Zotero.Utilities.Item", function () {
 			}
 
 		});
-		it("should recognize the legacy shortTitle key", function () {
+		it("should recognize the legacy shortTitle key", async function () {
 			let data = loadSampleData('citeProcJSExport');
 
 			var json = data.artwork;
@@ -34,28 +34,28 @@ describe("Zotero.Utilities.Item", function () {
 			let item = newItem();
 			Zotero.Utilities.Item.itemFromCSLJSON(item, json);
 
-			let newJSON = Zotero.Utilities.Item.itemToCSLJSON(item);
+			let newJSON = await Zotero.Utilities.Item.itemToCSLJSON(item);
 			assert.hasAllKeys(newJSON, canonicalKeys);
 		});
-		it("should import exported standalone note", function () {
+		it("should import exported standalone note", async function () {
 			let note = newItem('note');
 			note.note = 'Some note longer than 50 characters, which will become the title.';
 
-			let jsonNote = Zotero.Utilities.Item.itemToCSLJSON(note);
+			let jsonNote = await Zotero.Utilities.Item.itemToCSLJSON(note);
 
 			let item = newItem();
 			Zotero.Utilities.Item.itemFromCSLJSON(item, jsonNote);
 
 			assert.equal(item.title, jsonNote.title, 'title imported correctly');
 		});
-		it("should import exported standalone attachment", function () {
+		it("should import exported standalone attachment", async function () {
 			let attachment = newItem('attachment');
 			attachment.title = 'Empty';
 			attachment.accessDate = '2001-02-03 12:13:14';
 			attachment.url = 'http://example.com';
 			attachment.note = 'Note';
 
-			let jsonAttachment = Zotero.Utilities.Item.itemToCSLJSON(attachment);
+			let jsonAttachment = await Zotero.Utilities.Item.itemToCSLJSON(attachment);
 
 			let item = newItem();
 			Zotero.Utilities.Item.itemFromCSLJSON(item, jsonAttachment);
@@ -98,7 +98,7 @@ describe("Zotero.Utilities.Item", function () {
 
 			let fromZoteroItem;
 			try {
-				fromZoteroItem = Zotero.Utilities.Item.itemToCSLJSON(item);
+				fromZoteroItem = await Zotero.Utilities.Item.itemToCSLJSON(item);
 			} catch (e) {
 				assert.fail(e, null, 'accepts Zotero Item');
 			}
@@ -108,7 +108,7 @@ describe("Zotero.Utilities.Item", function () {
 
 			let fromExportItem;
 			try {
-				fromExportItem = Zotero.Utilities.Item.itemToCSLJSON(
+				fromExportItem = await Zotero.Utilities.Item.itemToCSLJSON(
 					Zotero.Utilities.Internal.itemToExportFormat(item)
 				);
 			} catch (e) {
@@ -119,22 +119,22 @@ describe("Zotero.Utilities.Item", function () {
 
 			assert.deepEqual(fromZoteroItem, fromExportItem, 'conversion from Zotero Item and from export item are the same');
 		});
-		it("should convert standalone notes to expected format", function () {
+		it("should convert standalone notes to expected format", async function () {
 			let note = newItem('note');
 			note.note = 'Some note longer than 50 characters, which will become the title.';
 
-			let cslJSONNote = Zotero.Utilities.Item.itemToCSLJSON(note);
+			let cslJSONNote = await Zotero.Utilities.Item.itemToCSLJSON(note);
 			assert.equal(cslJSONNote.type, 'document', 'note is exported as "document"');
-			assert.equal(cslJSONNote.title, Zotero.Utilities.Item.noteToTitle(note.note), 'note title is set to Zotero pseudo-title');
+			assert.equal(cslJSONNote.title, await Zotero.Utilities.Item.noteToTitle(note.note), 'note title is set to Zotero pseudo-title');
 		});
-		it("should convert standalone attachments to expected format", function () {
+		it("should convert standalone attachments to expected format", async function () {
 			let attachment = newItem('attachment');
 			attachment.title = 'Empty';
 			attachment.accessDate = '2001-02-03 12:13:14';
 			attachment.url = 'http://example.com';
 			attachment.note = 'Note';
 
-			let cslJSONAttachment = Zotero.Utilities.Item.itemToCSLJSON(attachment);
+			let cslJSONAttachment = await Zotero.Utilities.Item.itemToCSLJSON(attachment);
 			assert.equal(cslJSONAttachment.type, 'document', 'attachment is exported as "document"');
 			assert.equal(cslJSONAttachment.title, 'Empty', 'attachment title is correct');
 			assert.deepEqual(cslJSONAttachment.accessed, { "date-parts": [["2001", 2, 3]] }, 'attachment access date is mapped correctly');
@@ -147,7 +147,7 @@ describe("Zotero.Utilities.Item", function () {
 			assert.throws(Zotero.Utilities.Item.itemToCSLJSON.bind(Zotero.Utilities, item), /^Unexpected Zotero Item type ".*"$/, 'throws an error when trying to map invalid item types');
 		});
 
-		it("should parse particles in creator names", function () {
+		it("should parse particles in creator names", async function () {
 			let creators = [
 				{
 					// No particles
@@ -216,7 +216,7 @@ describe("Zotero.Utilities.Item", function () {
 
 			let item = newItem('journalArticle');
 			item.creators = creators;
-			let cslCreators = Zotero.Utilities.Item.itemToCSLJSON(item).author;
+			let cslCreators = await Zotero.Utilities.Item.itemToCSLJSON(item).author;
 
 			assert.deepEqual(cslCreators[0], creators[0].expect, 'simple name is not parsed');
 			assert.deepEqual(cslCreators[1], creators[1].expect, 'name with dropping and non-dropping particles is parsed');
@@ -226,7 +226,7 @@ describe("Zotero.Utilities.Item", function () {
 			assert.deepEqual(cslCreators[5], creators[5].expect, 'protected last name prevents parsing');
 		});
 
-		it("should convert UTC access date to local time", function () {
+		it("should convert UTC access date to local time", async function () {
 			var offset = new Date().getTimezoneOffset();
 			var item = newItem('webpage');
 			var localDate;
@@ -242,17 +242,17 @@ describe("Zotero.Utilities.Item", function () {
 			}
 			var utcDate = Zotero.Date.sqlToDate(localDate);
 			item.accessDate = Zotero.Date.dateToSQL(utcDate, true);
-			let accessed = Zotero.Utilities.Item.itemToCSLJSON(item).accessed;
+			let accessed = await Zotero.Utilities.Item.itemToCSLJSON(item).accessed;
 
 			assert.equal(accessed['date-parts'][0][0], 2019);
 			assert.equal(accessed['date-parts'][0][1], 1);
 			assert.equal(accessed['date-parts'][0][2], 9);
 		});
 		
-		it("should export Place as CSL `event-place` for Presentation item", function () {
+		it("should export Place as CSL `event-place` for Presentation item", async function () {
 			var item = newItem('presentation');
 			item.place = 'New York';
-			var json = Zotero.Utilities.Item.itemToCSLJSON(item);
+			var json = await Zotero.Utilities.Item.itemToCSLJSON(item);
 			assert.propertyVal(json, 'event-place', 'New York');
 			assert.notProperty(json, 'publisher-place');
 		});
@@ -260,21 +260,21 @@ describe("Zotero.Utilities.Item", function () {
 
 
 	describe("#noteToTitle()", function () {
-		it("should stop after first block element with content", function () {
+		it("should stop after first block element with content", async function () {
 			var str = "<h1>Foo</h1><p>Bar</p>";
-			var title = Zotero.Utilities.Item.noteToTitle(str, { stopAtLineBreak: true });
+			var title = await Zotero.Utilities.Item.noteToTitle(str, { stopAtLineBreak: true });
 			assert.equal(title, 'Foo');
 		});
 
-		it("should skip first line if no content", function () {
+		it("should skip first line if no content", async function () {
 			var str = "<blockquote>\n<p>Foo</p>\n</blockquote>\n<p>Bar</p>";
-			var title = Zotero.Utilities.Item.noteToTitle(str);
+			var title = await Zotero.Utilities.Item.noteToTitle(str);
 			assert.equal(title, 'Foo');
 		});
 
-		it("should stop at <br/> when options.stopAtLineBreak is true", function () {
+		it("should stop at <br/> when options.stopAtLineBreak is true", async function () {
 			var str = "<h1>Annotations<br/>(2/18/2022, 3:49:43 AM)</h1><p>Foo</p>";
-			var title = Zotero.Utilities.Item.noteToTitle(str, { stopAtLineBreak: true });
+			var title = await Zotero.Utilities.Item.noteToTitle(str, { stopAtLineBreak: true });
 			assert.equal(title, 'Annotations');
 		});
 	});

--- a/utilities.js
+++ b/utilities.js
@@ -26,7 +26,11 @@
     ***** END LICENSE BLOCK *****
 */
 
-(function() {
+import XRegExp from 'xregexp';
+import 'xregexp/lib/addons/unicode-base.js';
+import 'xregexp/lib/addons/unicode-categories.js';
+import 'xregexp/lib/addons/unicode-properties.js';
+import 'xregexp/lib/addons/unicode-scripts.js';
 
 function movedToUtilitiesInternal(fnName) {
 	return function () {
@@ -42,7 +46,7 @@ function movedToUtilitiesInternal(fnName) {
 /**
  * @class Functions for text manipulation and other miscellaneous purposes
  */
-var Utilities = {
+const Utilities = {
 	/**
 	 * Returns a function which will execute `fn` with provided arguments after `delay` milliseconds and not more
 	 * than once, if called multiple times. See
@@ -388,7 +392,7 @@ var Utilities = {
 		var ids = text.split(/[\s\u00A0]+/); // whitespace + non-breaking space
 		var doi;
 		for (let id of ids) {
-			if ((doi = Zotero.Utilities.cleanDOI(id)) && !foundIDs.has(doi)) {
+			if ((doi = Utilities.cleanDOI(id)) && !foundIDs.has(doi)) {
 				identifiers.push({
 					DOI: doi
 				});
@@ -404,7 +408,7 @@ var Utilities = {
 			let ISBN_RE = /(?:\D|^)(97[89]\d{10}|\d{9}[\dX])(?!\d)/g;
 			let isbn;
 			while (isbn = ISBN_RE.exec(ids)) {
-				isbn = Zotero.Utilities.cleanISBN(isbn[1]);
+				isbn = Utilities.cleanISBN(isbn[1]);
 				if (isbn && !foundIDs.has(isbn)) {
 					identifiers.push({
 						ISBN: isbn
@@ -417,7 +421,7 @@ var Utilities = {
 			if (!identifiers.length) {
 				ids = ids.replace(/[ \u00A0]+/g, ""); // space + non-breaking space
 				while (isbn = ISBN_RE.exec(ids)) {
-					isbn = Zotero.Utilities.cleanISBN(isbn[1]);
+					isbn = Utilities.cleanISBN(isbn[1]);
 					if(isbn && !foundIDs.has(isbn)) {
 						identifiers.push({
 							ISBN: isbn
@@ -699,7 +703,7 @@ var Utilities = {
 	"unescapeHTML":new function() {
 		var nsIScriptableUnescapeHTML, node;
 
-		return function(/**String*/ str) {
+		return async function(/**String*/ str) {
 			// If no tags, no need to unescape
 			if(str.indexOf("<") === -1 && str.indexOf("&") === -1) return str;
 
@@ -713,7 +717,7 @@ var Utilities = {
 				node.innerHTML = str;
 				return node.textContent.replace(/ {2,}/g, " ");
 			} else if(Zotero.isNode) {
-				let {JSDOM} = require('jsdom');
+				let {JSDOM} = await import("jsdom");
 				let document = (new JSDOM(str)).window.document;
 				return document.documentElement.textContent.replace(/ {2,}/g, " ");
 			} else {
@@ -1732,31 +1736,17 @@ var Utilities = {
 	 * Generates a valid object key for the server API
 	 */
 	generateObjectKey: function generateObjectKey() {
-		return Zotero.Utilities.randomString(8, Zotero.Utilities.allowedKeyChars);
+		return Utilities.randomString(8, Utilities.allowedKeyChars);
 	},
 
 	/**
 	 * Check if an object key is in a valid format
 	 */
 	isValidObjectKey: function(key) {
-		if (!Zotero.Utilities.objectKeyRegExp) {
-			Zotero.Utilities.objectKeyRegExp = new RegExp('^[' + Zotero.Utilities.allowedKeyChars + ']{8}$');
+		if (!Utilities.objectKeyRegExp) {
+			Utilities.objectKeyRegExp = new RegExp('^[' + Utilities.allowedKeyChars + ']{8}$');
 		}
-		return Zotero.Utilities.objectKeyRegExp.test(key);
-	},
-
-	itemTypeExists: function(type) {
-		Zotero.debug(`Zotero.Utilities.itemTypeExists() is deprecated -- use Zotero.Utilities.Item.itemTypeExists() instead`);
-		return Zotero.Utilities.Item.itemTypeExists(type);
-	},
-	
-	itemToCSLJSON: function(zoteroItem) {
-		Zotero.debug(`Zotero.Utilities.itemToCSLJSON() is deprecated -- use Zotero.Utilities.Item.itemToCSLJSON() instead`);
-		return Zotero.Utilities.Item.itemToCSLJSON(zoteroItem);
-	},
-	itemFromCSLJSON: function(item, cslItem) {
-		Zotero.debug(`Zotero.Utilities.itemFromCSLJSON() is deprecated -- use Zotero.Utilities.Item.itemFromCSLJSON() instead`);
-		return Zotero.Utilities.Item.itemFromCSLJSON(item, cslItem);
+		return Utilities.objectKeyRegExp.test(key);
 	},
 
 	assignProps: movedToUtilitiesInternal("assignProps"),
@@ -1782,7 +1772,7 @@ var Utilities = {
 	 * @param {Function} [visitors.visitURI] Return a replacement for the passed URI
 	 * @return {String} Potentially modified note HTML
 	 */
-	walkNoteDOM: function (note, visitors) {
+	walkNoteDOM: async function (note, visitors) {
 		function visit(elem) {
 			if (elem.hasAttribute('data-schema-version')) {
 				visitors.visitContainer?.(elem);
@@ -1843,7 +1833,7 @@ var Utilities = {
 		let wrappedNote = '<div id="note-body">' + note + '</div>';
 		let doc;
 		if (Zotero.isNode) {
-			let { JSDOM } = require('jsdom');
+			let { JSDOM } = await import('jsdom');
 			doc = new JSDOM(wrappedNote).window.document;
 		}
 		else {
@@ -1870,19 +1860,8 @@ var Utilities = {
 	//  * Provides unicode support and other additional features for regular expressions
 	//  * See https://github.com/slevithan/xregexp for usage
 	//  */
-	XRegExp: typeof XRegExp !== "undefined" ? XRegExp : null
-}
+	XRegExp: XRegExp
+};
 
-if (!Utilities.XRegExp) {
-	if (typeof module != 'undefined') {
-		Utilities.XRegExp = require('./xregexp-all');
-	}
-}
-
-if (typeof module != 'undefined') {
-	module.exports = Utilities;
-} else if (typeof Zotero != 'undefined') {
-	Zotero.Utilities = Utilities;
-}
-
-})();
+export { Utilities }
+export default Utilities

--- a/utilities_item.js
+++ b/utilities_item.js
@@ -23,12 +23,9 @@
 	***** END LICENSE BLOCK *****
 */
 
-(function() {
+import Utilities from "./utilities.js";
 
-// Various Utility functions related to Zotero, API, Translation Item formats
-// and their conversion or field access.
-
-var Utilities_Item = {
+const Utilities_Item = {
 	PARTICLE_GIVEN_REGEXP: /^([^ ]+(?:\u02bb |\u2019 | |\' ) *)(.+)$/,
 	PARTICLE_FAMILY_REGEXP: /^([^ ]+(?:\-|\u02bb|\u2019| |\') *)(.+)$/,
 	
@@ -48,14 +45,14 @@ var Utilities_Item = {
 	 * @return {Object|Promise<Object>} A CSL item, or a promise for a CSL item if a Zotero.Item
 	 *     is passed
 	 */
-	itemToCSLJSON: function(zoteroItem) {
+	itemToCSLJSON: async function(zoteroItem) {
 		// If a Zotero.Item was passed, convert it to the proper format (skipping child items) and
 		// call this function again with that object
 		//
 		// (Zotero.Item won't be defined in translation-server)
 		if (typeof Zotero.Item !== 'undefined' && zoteroItem instanceof Zotero.Item) {
-			return Utilities_Item.itemToCSLJSON(
-				Zotero.Utilities.Internal.itemToExportFormat(zoteroItem, {
+			return await Utilities_Item.itemToCSLJSON(
+				Utilities.Internal.itemToExportFormat(zoteroItem, {
 					skipChildItems: true
 				})
 			);
@@ -122,7 +119,7 @@ var Utilities_Item = {
 						if (isbn) value = isbn[0];
 					}
 					else if (field == 'extra') {
-						value = Zotero.Utilities.Item.extraToCSL(value);
+						value = Utilities_Item.extraToCSL(value);
 					}
 
 					// Strip enclosing quotes
@@ -169,7 +166,7 @@ var Utilities_Item = {
 						) {
 							nameObj.family = nameObj.family.substr(1, nameObj.family.length - 2);
 						} else {
-							Zotero.Utilities.Item.parseParticles(nameObj);
+							Utilities_Item.parseParticles(nameObj);
 						}
 					}
 				}
@@ -231,7 +228,7 @@ var Utilities_Item = {
 
 		// Special mapping for note title
 		if (zoteroItem.itemType == 'note' && zoteroItem.note) {
-			cslItem.title = Zotero.Utilities.Item.noteToTitle(zoteroItem.note);
+			cslItem.title = await Utilities_Item.noteToTitle(zoteroItem.note);
 		}
 
 		//this._cache[zoteroItem.id] = cslItem;
@@ -406,7 +403,7 @@ var Utilities_Item = {
 							date = Zotero.Date.strToISO(date);
 						}
 					} else {
-						var newDate = Zotero.Utilities.deepCopy(cslDate);
+						var newDate = Utilities.deepCopy(cslDate);
 						if(cslDate["date-parts"] && typeof cslDate["date-parts"] === "object"
 							&& cslDate["date-parts"] !== null
 							&& typeof cslDate["date-parts"][0] === "object"
@@ -419,11 +416,11 @@ var Utilities_Item = {
 						if(newDate.year) {
 							if(variable === "accessed") {
 								// Need to convert to SQL
-								var date = Zotero.Utilities.lpad(newDate.year, "0", 4);
+								var date = Utilities.lpad(newDate.year, "0", 4);
 								if(newDate.month) {
-									date += "-"+Zotero.Utilities.lpad(newDate.month, "0", 2);
+									date += "-"+Utilities.lpad(newDate.month, "0", 2);
 									if(newDate.day) {
-										date += "-"+Zotero.Utilities.lpad(newDate.day, "0", 2);
+										date += "-"+Utilities.lpad(newDate.day, "0", 2);
 									}
 								}
 							} else {
@@ -620,7 +617,7 @@ var Utilities_Item = {
 	 * @param {Boolean} [options.stopAtLineBreak] - Stop at <br/> instead of converting to space
 	 * @return {String}
 	 */
-	noteToTitle: function (text, options = {}) {
+	noteToTitle: async function (text, options = {}) {
 		var MAX_TITLE_LENGTH = 120;
 		var origText = text;
 		text = text.trim();
@@ -632,7 +629,7 @@ var Utilities_Item = {
 		else {
 			text = text.replace(/<br\s*\/?>/g, ' ');
 		}
-		text = Zotero.Utilities.unescapeHTML(text);
+		text = await Utilities.unescapeHTML(text);
 
 		// If first line is just an opening HTML tag, remove it
 		//
@@ -849,7 +846,7 @@ var Utilities_Item = {
 	 */
 	itemToAPIJSON: function(item) {
 		var newItem = {
-				key: Zotero.Utilities.generateObjectKey(),
+				key: Utilities.generateObjectKey(),
 				version: 0
 			},
 			newItems = [newItem];
@@ -1015,8 +1012,8 @@ var Utilities_Item = {
 		}
 
 		// Meaningless local item ID, but some older export translators depend on it
-		item.itemID = Zotero.Utilities.randomString(6);
-		item.key = Zotero.Utilities.randomString(6); // CSV translator exports this
+		item.itemID = Utilities.randomString(6);
+		item.key = Utilities.randomString(6); // CSV translator exports this
 
 		// "version" is expected to be a field for "computerProgram", which is now
 		// called "versionNumber"
@@ -1137,15 +1134,8 @@ var Utilities_Item = {
 		}
 
 		return Zotero.localeCompare(fieldA, fieldB);
-	}
-}
+	},
+};
 
-if (typeof module != 'undefined') {
-	module.exports = Utilities_Item;
-} else if (typeof Zotero != 'undefined' && typeof Zotero.Utilities != 'undefined') {
-	Zotero.Utilities.Item = Utilities_Item;
-} else {
-	console.log('Could not find a way to expose utilities_item.js. Check your load order.')
-}
-
-})();
+export { Utilities_Item };
+export default Utilities_Item;


### PR DESCRIPTION
I've migrated the whole codebase to ESM (including updating package metadata, converting core modules and tests, and refreshing the README examples for ESM imports).

Moving to ESM matches modern Node/browser module semantics, and down the road enables tree-shaking and better static analysis.

I should note that this is a breaking change as one cannot `require` an ESM module. Normally, this is addressed by having a bundler (like rollup) emit CJS and ESM at the same time, and ship that. But the other Zotero projects are just including this repo verbatim, so this is not really an option. On the other hand, one has to start with the migration somewhere and the utilities (and later translator) repo is a good starting point.