### PR TITLE
Refactor regex patterns to use native RegExp

### DIFF
--- a/date.js
+++ b/date.js
@@ -93,8 +93,7 @@ var Utilities_Date = new function(){
 		
 		let months = _monthsWithEnglish.short.map(m => m.toLowerCase())
 			.concat(_monthsWithEnglish.long.map(m => m.toLowerCase()));
-		// TODO: Switch back to native RegExp in Fx102 when Unicode property escapes are supported
-		_monthRe = Zotero.Utilities.XRegExp("(.*)(?:^|[^\\p{L}])(" + months.join("|") + ")[^ ]*(?: (.*)$|$)", "iu");
+		_monthRe = new RegExp("(.*)(?:^|[^\\p{L}])(" + months.join("|") + ")[^ ]*(?: (.*)$|$)", "iu");
 	};
 
 

--- a/utilities.js
+++ b/utilities.js
@@ -203,11 +203,7 @@ var Utilities = {
 		return string.split(' ')
 			.map((part) => {
 				if (part.toUpperCase() === part || part.toLowerCase() === part) {
-					return Utilities.XRegExp.replace(
-						part.toLowerCase(),
-						Utilities.XRegExp('(^|[^\\pL])\\pL', 'g'),
-						m => m.toUpperCase()
-					);
+					return part.toLowerCase().replace(/(^|[^\p{L}])\p{L}/gu, m => m.toUpperCase());
 				}
 				else {
 					return part;
@@ -257,7 +253,7 @@ var Utilities = {
 				spaceIndex = author.lastIndexOf(" ", spaceIndex-1);
 				var lastName = author.substring(spaceIndex + 1);
 				var firstName = author.substring(0, spaceIndex);
-			} while (!Utilities.XRegExp('\\pL').test(lastName[0]) && spaceIndex > 0)
+			} while (!/\p{L}/u.test(lastName[0] || '') && spaceIndex > 0)
 		}
 
 		if(firstName && allCapsRe.test(firstName) &&


### PR DESCRIPTION
Insead of relying on the somewhat (out)dated XRegex package, native regex are now used. The unicode properties feature that is used in those regex is supported since about 5  years in all browsers. 